### PR TITLE
Make go-spacemesh linter happy

### DIFF
--- a/examples/bytes_scale.go
+++ b/examples/bytes_scale.go
@@ -8,8 +8,8 @@ import (
 
 func (t *Bytes20) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteArray(enc, t.Value[:]); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -17,8 +17,8 @@ func (t *Bytes20) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Bytes20) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if n, err := scale.DecodeByteArray(dec, t.Value[:]); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -26,8 +26,8 @@ func (t *Bytes20) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *Bytes32) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteArray(enc, t.Value[:]); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -35,8 +35,8 @@ func (t *Bytes32) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Bytes32) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if n, err := scale.DecodeByteArray(dec, t.Value[:]); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -44,8 +44,8 @@ func (t *Bytes32) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *Bytes64) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteArray(enc, t.Value[:]); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -53,8 +53,8 @@ func (t *Bytes64) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Bytes64) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if n, err := scale.DecodeByteArray(dec, t.Value[:]); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -62,8 +62,8 @@ func (t *Bytes64) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *Slice) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteSlice(enc, t.Value); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -71,8 +71,8 @@ func (t *Slice) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Slice) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeByteSlice(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Value = field
 	}
@@ -81,8 +81,8 @@ func (t *Slice) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *SliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteSliceWithLimit(enc, t.Value, 10); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -90,8 +90,8 @@ func (t *SliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, err error) 
 
 func (t *SliceWithLimit) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeByteSliceWithLimit(dec, 10); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Value = field
 	}
@@ -100,8 +100,8 @@ func (t *SliceWithLimit) DecodeScale(dec *scale.Decoder) (total int, err error) 
 
 func (t *SliceOfByteSliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeSliceOfByteSlice(enc, t.Value); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -109,8 +109,8 @@ func (t *SliceOfByteSliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, 
 
 func (t *SliceOfByteSliceWithLimit) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeSliceOfByteSlice(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Value = field
 	}

--- a/examples/bytes_scale.go
+++ b/examples/bytes_scale.go
@@ -8,7 +8,7 @@ import (
 
 func (t *Bytes20) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteArray(enc, t.Value[:]); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -17,7 +17,7 @@ func (t *Bytes20) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Bytes20) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if n, err := scale.DecodeByteArray(dec, t.Value[:]); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -26,7 +26,7 @@ func (t *Bytes20) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *Bytes32) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteArray(enc, t.Value[:]); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -35,7 +35,7 @@ func (t *Bytes32) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Bytes32) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if n, err := scale.DecodeByteArray(dec, t.Value[:]); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -44,7 +44,7 @@ func (t *Bytes32) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *Bytes64) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteArray(enc, t.Value[:]); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -53,7 +53,7 @@ func (t *Bytes64) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Bytes64) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if n, err := scale.DecodeByteArray(dec, t.Value[:]); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -62,7 +62,7 @@ func (t *Bytes64) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *Slice) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteSlice(enc, t.Value); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -71,7 +71,7 @@ func (t *Slice) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Slice) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeByteSlice(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 		t.Value = field
@@ -81,7 +81,7 @@ func (t *Slice) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *SliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteSliceWithLimit(enc, t.Value, 10); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -90,7 +90,7 @@ func (t *SliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, err error) 
 
 func (t *SliceWithLimit) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeByteSliceWithLimit(dec, 10); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 		t.Value = field
@@ -100,7 +100,7 @@ func (t *SliceWithLimit) DecodeScale(dec *scale.Decoder) (total int, err error) 
 
 func (t *SliceOfByteSliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeSliceOfByteSlice(enc, t.Value); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -109,7 +109,7 @@ func (t *SliceOfByteSliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, 
 
 func (t *SliceOfByteSliceWithLimit) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeSliceOfByteSlice(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 		t.Value = field

--- a/examples/ex1_scale.go
+++ b/examples/ex1_scale.go
@@ -9,12 +9,12 @@ import (
 func (t *Ex1) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeOption(enc, t.Option); err != nil {
 		return total, err
-	} else {
+	} else { // nolint
 		total += n
 	}
 	if n, err := scale.EncodeBool(enc, t.Bool); err != nil {
 		return total, err
-	} else {
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -23,13 +23,13 @@ func (t *Ex1) EncodeScale(enc *scale.Encoder) (total int, err error) {
 func (t *Ex1) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeOption[Ex1](dec); err != nil {
 		return total, err
-	} else {
+	} else { // nolint
 		total += n
 		t.Option = field
 	}
 	if field, n, err := scale.DecodeBool(dec); err != nil {
 		return total, err
-	} else {
+	} else { // nolint
 		total += n
 		t.Bool = field
 	}

--- a/examples/ex2_scale.go
+++ b/examples/ex2_scale.go
@@ -9,12 +9,12 @@ import (
 func (t *Ex2) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeStructSlice(enc, t.Slice); err != nil {
 		return total, err
-	} else {
+	} else { // nolint
 		total += n
 	}
 	if n, err := scale.EncodeStructArray(enc, t.Array[:]); err != nil {
 		return total, err
-	} else {
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -23,22 +23,22 @@ func (t *Ex2) EncodeScale(enc *scale.Encoder) (total int, err error) {
 func (t *Ex2) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeStructSlice[Ex2](dec); err != nil {
 		return total, err
-	} else {
+	} else { // nolint
 		total += n
 		t.Slice = field
 	}
 	if n, err := scale.DecodeStructArray(dec, t.Array[:]); err != nil {
 		return total, err
-	} else {
+	} else { // nolint
 		total += n
 	}
 	return total, nil
 }
 
 func (t *Smth) EncodeScale(enc *scale.Encoder) (total int, err error) {
-	if n, err := scale.EncodeCompact32(enc, t.Val); err != nil {
+	if n, err := scale.EncodeCompact32(enc, uint32(t.Val)); err != nil {
 		return total, err
-	} else {
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -47,9 +47,9 @@ func (t *Smth) EncodeScale(enc *scale.Encoder) (total int, err error) {
 func (t *Smth) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact32(dec); err != nil {
 		return total, err
-	} else {
+	} else { // nolint
 		total += n
-		t.Val = field
+		t.Val = uint32(field)
 	}
 	return total, nil
 }
@@ -57,7 +57,7 @@ func (t *Smth) DecodeScale(dec *scale.Decoder) (total int, err error) {
 func (t *StructSliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeStructSliceWithLimit(enc, t.Slice, 2); err != nil {
 		return total, err
-	} else {
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -66,7 +66,7 @@ func (t *StructSliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, err e
 func (t *StructSliceWithLimit) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeStructSliceWithLimit[Smth](dec, 2); err != nil {
 		return total, err
-	} else {
+	} else { // nolint
 		total += n
 		t.Slice = field
 	}

--- a/examples/integers_scale.go
+++ b/examples/integers_scale.go
@@ -8,8 +8,8 @@ import (
 
 func (t *U8) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeCompact8(enc, uint8(t.Value)); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -17,8 +17,8 @@ func (t *U8) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *U8) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact8(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Value = uint8(field)
 	}
@@ -27,8 +27,8 @@ func (t *U8) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *U16) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeCompact16(enc, uint16(t.Value)); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -36,8 +36,8 @@ func (t *U16) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *U16) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact16(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Value = uint16(field)
 	}
@@ -46,8 +46,8 @@ func (t *U16) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *U32) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeCompact32(enc, uint32(t.Value)); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -55,8 +55,8 @@ func (t *U32) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *U32) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact32(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Value = uint32(field)
 	}
@@ -65,8 +65,8 @@ func (t *U32) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *U64) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeCompact64(enc, uint64(t.Value)); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -74,8 +74,8 @@ func (t *U64) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *U64) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact64(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Value = uint64(field)
 	}

--- a/examples/integers_scale.go
+++ b/examples/integers_scale.go
@@ -8,7 +8,7 @@ import (
 
 func (t *U8) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeCompact8(enc, uint8(t.Value)); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -17,7 +17,7 @@ func (t *U8) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *U8) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact8(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 		t.Value = uint8(field)
@@ -27,7 +27,7 @@ func (t *U8) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *U16) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeCompact16(enc, uint16(t.Value)); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -36,7 +36,7 @@ func (t *U16) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *U16) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact16(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 		t.Value = uint16(field)
@@ -46,7 +46,7 @@ func (t *U16) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *U32) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeCompact32(enc, uint32(t.Value)); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -55,7 +55,7 @@ func (t *U32) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *U32) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact32(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 		t.Value = uint32(field)
@@ -65,7 +65,7 @@ func (t *U32) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *U64) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeCompact64(enc, uint64(t.Value)); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -74,7 +74,7 @@ func (t *U64) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *U64) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact64(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 		t.Value = uint64(field)

--- a/examples/options_scale.go
+++ b/examples/options_scale.go
@@ -8,13 +8,13 @@ import (
 
 func (t *Options) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeOption(enc, t.ArrayPtr); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if n, err := scale.EncodeOption(enc, t.SlicePtr); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -22,14 +22,14 @@ func (t *Options) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Options) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeOption[array](dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.ArrayPtr = field
 	}
 	if field, n, err := scale.DecodeOption[slice](dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.SlicePtr = field
 	}

--- a/examples/options_scale.go
+++ b/examples/options_scale.go
@@ -8,12 +8,12 @@ import (
 
 func (t *Options) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeOption(enc, t.ArrayPtr); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
 	if n, err := scale.EncodeOption(enc, t.SlicePtr); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -22,13 +22,13 @@ func (t *Options) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Options) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeOption[array](dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 		t.ArrayPtr = field
 	}
 	if field, n, err := scale.DecodeOption[slice](dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 		t.SlicePtr = field

--- a/examples/spend_scale.go
+++ b/examples/spend_scale.go
@@ -8,13 +8,13 @@ import (
 
 func (t *Spend) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeCompact8(enc, uint8(t.Type)); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if n, err := t.Body.EncodeScale(enc); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -22,14 +22,14 @@ func (t *Spend) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Spend) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact8(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Type = uint8(field)
 	}
 	if n, err := t.Body.DecodeScale(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -37,18 +37,18 @@ func (t *Spend) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *SpendBody) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteArray(enc, t.Adress[:]); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if n, err := scale.EncodeCompact8(enc, uint8(t.Selector)); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if n, err := t.Payload.EncodeScale(enc); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -56,19 +56,19 @@ func (t *SpendBody) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *SpendBody) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if n, err := scale.DecodeByteArray(dec, t.Adress[:]); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if field, n, err := scale.DecodeCompact8(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Selector = uint8(field)
 	}
 	if n, err := t.Payload.DecodeScale(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -76,23 +76,23 @@ func (t *SpendBody) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *SpendPayload) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := t.Arguments.EncodeScale(enc); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if n, err := t.Nonce.EncodeScale(enc); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if n, err := scale.EncodeCompact32(enc, uint32(t.GasPrice)); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if n, err := scale.EncodeByteArray(enc, t.Signature[:]); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -100,24 +100,24 @@ func (t *SpendPayload) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *SpendPayload) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if n, err := t.Arguments.DecodeScale(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if n, err := t.Nonce.DecodeScale(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if field, n, err := scale.DecodeCompact32(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.GasPrice = uint32(field)
 	}
 	if n, err := scale.DecodeByteArray(dec, t.Signature[:]); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -125,13 +125,13 @@ func (t *SpendPayload) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *SpendArguments) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteArray(enc, t.Recipient[:]); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if n, err := scale.EncodeCompact64(enc, uint64(t.Amount)); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -139,13 +139,13 @@ func (t *SpendArguments) EncodeScale(enc *scale.Encoder) (total int, err error) 
 
 func (t *SpendArguments) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if n, err := scale.DecodeByteArray(dec, t.Recipient[:]); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if field, n, err := scale.DecodeCompact64(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Amount = uint64(field)
 	}
@@ -154,13 +154,13 @@ func (t *SpendArguments) DecodeScale(dec *scale.Decoder) (total int, err error) 
 
 func (t *SpendNonce) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeCompact32(enc, uint32(t.Counter)); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	if n, err := scale.EncodeCompact64(enc, uint64(t.Bitfield)); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -168,14 +168,14 @@ func (t *SpendNonce) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *SpendNonce) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact32(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Counter = uint32(field)
 	}
 	if field, n, err := scale.DecodeCompact64(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Bitfield = uint64(field)
 	}

--- a/examples/spend_scale.go
+++ b/examples/spend_scale.go
@@ -7,13 +7,13 @@ import (
 )
 
 func (t *Spend) EncodeScale(enc *scale.Encoder) (total int, err error) {
-	if n, err := scale.EncodeCompact8(enc, t.Type); err != nil {
-		return total, err
+	if n, err := scale.EncodeCompact8(enc, uint8(t.Type)); err != nil {
+		return total, err // nolint
 	} else {
 		total += n
 	}
 	if n, err := t.Body.EncodeScale(enc); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -22,13 +22,13 @@ func (t *Spend) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Spend) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact8(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
-		t.Type = field
+		t.Type = uint8(field)
 	}
 	if n, err := t.Body.DecodeScale(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -37,17 +37,17 @@ func (t *Spend) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *SpendBody) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteArray(enc, t.Adress[:]); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
-	if n, err := scale.EncodeCompact8(enc, t.Selector); err != nil {
-		return total, err
+	if n, err := scale.EncodeCompact8(enc, uint8(t.Selector)); err != nil {
+		return total, err // nolint
 	} else {
 		total += n
 	}
 	if n, err := t.Payload.EncodeScale(enc); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -56,18 +56,18 @@ func (t *SpendBody) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *SpendBody) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if n, err := scale.DecodeByteArray(dec, t.Adress[:]); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
 	if field, n, err := scale.DecodeCompact8(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
-		t.Selector = field
+		t.Selector = uint8(field)
 	}
 	if n, err := t.Payload.DecodeScale(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -76,22 +76,22 @@ func (t *SpendBody) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *SpendPayload) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := t.Arguments.EncodeScale(enc); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
 	if n, err := t.Nonce.EncodeScale(enc); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
-	if n, err := scale.EncodeCompact32(enc, t.GasPrice); err != nil {
-		return total, err
+	if n, err := scale.EncodeCompact32(enc, uint32(t.GasPrice)); err != nil {
+		return total, err // nolint
 	} else {
 		total += n
 	}
 	if n, err := scale.EncodeByteArray(enc, t.Signature[:]); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -100,23 +100,23 @@ func (t *SpendPayload) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *SpendPayload) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if n, err := t.Arguments.DecodeScale(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
 	if n, err := t.Nonce.DecodeScale(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
 	if field, n, err := scale.DecodeCompact32(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
-		t.GasPrice = field
+		t.GasPrice = uint32(field)
 	}
 	if n, err := scale.DecodeByteArray(dec, t.Signature[:]); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -125,12 +125,12 @@ func (t *SpendPayload) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *SpendArguments) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeByteArray(enc, t.Recipient[:]); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
-	if n, err := scale.EncodeCompact64(enc, t.Amount); err != nil {
-		return total, err
+	if n, err := scale.EncodeCompact64(enc, uint64(t.Amount)); err != nil {
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -139,27 +139,27 @@ func (t *SpendArguments) EncodeScale(enc *scale.Encoder) (total int, err error) 
 
 func (t *SpendArguments) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if n, err := scale.DecodeByteArray(dec, t.Recipient[:]); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
 	if field, n, err := scale.DecodeCompact64(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
-		t.Amount = field
+		t.Amount = uint64(field)
 	}
 	return total, nil
 }
 
 func (t *SpendNonce) EncodeScale(enc *scale.Encoder) (total int, err error) {
-	if n, err := scale.EncodeCompact32(enc, t.Counter); err != nil {
-		return total, err
+	if n, err := scale.EncodeCompact32(enc, uint32(t.Counter)); err != nil {
+		return total, err // nolint
 	} else {
 		total += n
 	}
-	if n, err := scale.EncodeCompact64(enc, t.Bitfield); err != nil {
-		return total, err
+	if n, err := scale.EncodeCompact64(enc, uint64(t.Bitfield)); err != nil {
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -168,16 +168,16 @@ func (t *SpendNonce) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *SpendNonce) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeCompact32(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
-		t.Counter = field
+		t.Counter = uint32(field)
 	}
 	if field, n, err := scale.DecodeCompact64(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
-		t.Bitfield = field
+		t.Bitfield = uint64(field)
 	}
 	return total, nil
 }

--- a/examples/string_scale.go
+++ b/examples/string_scale.go
@@ -8,8 +8,8 @@ import (
 
 func (t *StructWithString) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeString(enc, t.Value); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -17,8 +17,8 @@ func (t *StructWithString) EncodeScale(enc *scale.Encoder) (total int, err error
 
 func (t *StructWithString) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeString(dec); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Value = field
 	}
@@ -27,8 +27,8 @@ func (t *StructWithString) DecodeScale(dec *scale.Decoder) (total int, err error
 
 func (t *StructWithStringLimit) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeStringWithLimit(enc, t.Value, 3); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 	}
 	return total, nil
@@ -36,8 +36,8 @@ func (t *StructWithStringLimit) EncodeScale(enc *scale.Encoder) (total int, err 
 
 func (t *StructWithStringLimit) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeStringWithLimit(dec, 3); err != nil {
-		return total, err // nolint
-	} else {
+		return total, err
+	} else { // nolint
 		total += n
 		t.Value = field
 	}

--- a/examples/string_scale.go
+++ b/examples/string_scale.go
@@ -8,7 +8,7 @@ import (
 
 func (t *StructWithString) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeString(enc, t.Value); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -17,7 +17,7 @@ func (t *StructWithString) EncodeScale(enc *scale.Encoder) (total int, err error
 
 func (t *StructWithString) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeString(dec); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 		t.Value = field
@@ -27,7 +27,7 @@ func (t *StructWithString) DecodeScale(dec *scale.Decoder) (total int, err error
 
 func (t *StructWithStringLimit) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	if n, err := scale.EncodeStringWithLimit(enc, t.Value, 3); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 	}
@@ -36,7 +36,7 @@ func (t *StructWithStringLimit) EncodeScale(enc *scale.Encoder) (total int, err 
 
 func (t *StructWithStringLimit) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	if field, n, err := scale.DecodeStringWithLimit(dec, 3); err != nil {
-		return total, err
+		return total, err // nolint
 	} else {
 		total += n
 		t.Value = field

--- a/generate.go
+++ b/generate.go
@@ -46,13 +46,13 @@ var (
 	}
 	generic = temp{
 		encode: `if n, err := scale.Encode{{ .ScaleType }}(enc, t.{{ .Name }}{{.ScaleTypeArgs}}); err != nil {
-			return total, err
+			return total, err // nolint
 		} else {
 			total += n
 		}
 		`,
 		decode: `if field, n, err := scale.Decode{{ .ScaleType }}{{ .TypeInfo }}(dec{{.ScaleTypeArgs}}); err != nil {
-			return total, err
+			return total, err // nolint
 		} else {
 			total += n
 			t.{{ .Name }} = field
@@ -61,13 +61,13 @@ var (
 	}
 	genericTyped = temp{
 		encode: `if n, err := scale.Encode{{ .ScaleType }}(enc, {{.EncodeModifier}}(t.{{ .Name }}){{.ScaleTypeArgs}}); err != nil {
-			return total, err
+			return total, err // nolint
 		} else {
 			total += n
 		}
 		`,
 		decode: `if field, n, err := scale.Decode{{ .ScaleType }}{{ .TypeInfo }}(dec{{.ScaleTypeArgs}}); err != nil {
-			return total, err
+			return total, err // nolint
 		} else {
 			total += n
 			t.{{ .Name }} = {{.DecodeModifier}}(field)
@@ -76,13 +76,13 @@ var (
 	}
 	array = temp{
 		encode: `if n, err := scale.Encode{{ .ScaleType }}(enc, t.{{ .Name }}[:]{{.ScaleTypeArgs}}); err != nil {
-			return total, err
+			return total, err // nolint
 		} else {
 			total += n
 		}
 		`,
 		decode: `if n, err := scale.Decode{{ .ScaleType }}(dec, t.{{ .Name }}[:]{{.ScaleTypeArgs}}); err != nil {
-			return total, err
+			return total, err // nolint
 		} else {
 			total += n
 		}
@@ -90,13 +90,13 @@ var (
 	}
 	object = temp{
 		encode: `if n, err := t.{{ .Name }}.EncodeScale(enc); err != nil {
-			return total, err
+			return total, err // nolint
 		} else {
 			total += n
 		}
 		`,
 		decode: `if n, err := t.{{ .Name }}.DecodeScale(dec); err != nil {
-			return total, err
+			return total, err // nolint
 		} else {
 			total += n
 		}

--- a/generate.go
+++ b/generate.go
@@ -46,14 +46,14 @@ var (
 	}
 	generic = temp{
 		encode: `if n, err := scale.Encode{{ .ScaleType }}(enc, t.{{ .Name }}{{.ScaleTypeArgs}}); err != nil {
-			return total, err // nolint
-		} else {
+			return total, err
+		} else { // nolint
 			total += n
 		}
 		`,
 		decode: `if field, n, err := scale.Decode{{ .ScaleType }}{{ .TypeInfo }}(dec{{.ScaleTypeArgs}}); err != nil {
-			return total, err // nolint
-		} else {
+			return total, err
+		} else { // nolint
 			total += n
 			t.{{ .Name }} = field
 		}
@@ -61,14 +61,14 @@ var (
 	}
 	genericTyped = temp{
 		encode: `if n, err := scale.Encode{{ .ScaleType }}(enc, {{.EncodeModifier}}(t.{{ .Name }}){{.ScaleTypeArgs}}); err != nil {
-			return total, err // nolint
-		} else {
+			return total, err
+		} else { // nolint
 			total += n
 		}
 		`,
 		decode: `if field, n, err := scale.Decode{{ .ScaleType }}{{ .TypeInfo }}(dec{{.ScaleTypeArgs}}); err != nil {
-			return total, err // nolint
-		} else {
+			return total, err
+		} else { // nolint
 			total += n
 			t.{{ .Name }} = {{.DecodeModifier}}(field)
 		}
@@ -76,28 +76,28 @@ var (
 	}
 	array = temp{
 		encode: `if n, err := scale.Encode{{ .ScaleType }}(enc, t.{{ .Name }}[:]{{.ScaleTypeArgs}}); err != nil {
-			return total, err // nolint
-		} else {
+			return total, err
+		} else { // nolint
 			total += n
 		}
 		`,
 		decode: `if n, err := scale.Decode{{ .ScaleType }}(dec, t.{{ .Name }}[:]{{.ScaleTypeArgs}}); err != nil {
-			return total, err // nolint
-		} else {
+			return total, err
+		} else { // nolint
 			total += n
 		}
 		`,
 	}
 	object = temp{
 		encode: `if n, err := t.{{ .Name }}.EncodeScale(enc); err != nil {
-			return total, err // nolint
-		} else {
+			return total, err
+		} else { // nolint
 			total += n
 		}
 		`,
 		decode: `if n, err := t.{{ .Name }}.DecodeScale(dec); err != nil {
-			return total, err // nolint
-		} else {
+			return total, err
+		} else { // nolint
 			total += n
 		}
 		`,


### PR DESCRIPTION
to avoid linter errors like:
```
if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
```

This is needed to enable scale codec in https://github.com/spacemeshos/go-spacemesh as per  https://github.com/spacemeshos/go-spacemesh/issues/3271