### PR TITLE
Remove scale methods for deleted types on generate

### DIFF
--- a/scalegen/runner/runner.go
+++ b/scalegen/runner/runner.go
@@ -164,11 +164,12 @@ func cleanupScaleFile(dataFilePath, scaleFilePath string) error {
 	return nil
 }
 
-func getReceiver(recv *ast.FieldList) string {
-	if recv == nil {
+// getReceiver returns receiver type name for a function declaration.
+func getReceiver(f *ast.FuncDecl) string {
+	if f == nil || f.Recv == nil {
 		return ""
 	}
-	for _, field := range recv.List {
+	for _, field := range f.Recv.List {
 		switch typ := field.Type.(type) {
 		case *ast.StarExpr:
 			if si, ok := typ.X.(*ast.Ident); ok {
@@ -208,7 +209,7 @@ func filterDecls(decls []ast.Decl, dataFileTypes []string) []ast.Decl {
 		switch declType := decl.(type) {
 		case *ast.FuncDecl:
 			// skip scale method if receiver type is not defined in data file
-			receiverTypeName := getReceiver(declType.Recv)
+			receiverTypeName := getReceiver(declType)
 			if receiverTypeName == "" {
 				panic("receiver can't be empty")
 			}

--- a/scalegen/runner/runner_test.go
+++ b/scalegen/runner/runner_test.go
@@ -72,6 +72,7 @@ func TestCleanupScaleFile(t *testing.T) {
 			continue
 		}
 		t.Run(file.Name(), func(t *testing.T) {
+			dataFile := filepath.Join(dir, file.Name())
 			scaleFile := filepath.Join(dir, ScaleFile(file.Name()))
 			scaleEmptyFile := scaleFile + ".empty"
 
@@ -85,7 +86,7 @@ func TestCleanupScaleFile(t *testing.T) {
 			err = ioutil.WriteFile(scaleFileCopy, scaleFileData, 0644)
 			defer os.Remove(scaleFileCopy)
 
-			err = cleanupScaleFile(scaleFileCopy)
+			err = cleanupScaleFile(dataFile, scaleFileCopy)
 			require.NoError(t, err)
 
 			scaleFileCopyData, err := os.ReadFile(scaleFileCopy)

--- a/scalegen/runner/testdata/data.go
+++ b/scalegen/runner/testdata/data.go
@@ -9,10 +9,13 @@ type Data struct {
 	NestedStruct        nested.Struct
 	NestedStructPointer *nested.Struct
 	NestedStructSlice   []nested.Struct
-	NestedAlias         nested.StringAlias
-	StrSlice            []string
-	ByteArray           [20]byte
-	ByteSlice           []byte
-	SliceOfByteSlices   [][]byte
-	Uint64              uint64
+}
+
+type MoreData struct {
+	NestedAlias       nested.StringAlias
+	StrSlice          []string
+	ByteArray         [20]byte
+	ByteSlice         []byte
+	SliceOfByteSlices [][]byte
+	Uint64            uint64
 }

--- a/scalegen/runner/testdata/data_scale.go
+++ b/scalegen/runner/testdata/data_scale.go
@@ -37,6 +37,45 @@ func (t *Data) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		}
 		total += n
 	}
+	return total, nil
+}
+
+func (t *Data) DecodeScale(dec *scale.Decoder) (total int, err error) {
+	{
+		field, n, err := scale.DecodeString(dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+		t.Str = string(field)
+	}
+	{
+		n, err := t.NestedStruct.DecodeScale(dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	{
+		field, n, err := scale.DecodeOption[nested.Struct](dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+		t.NestedStructPointer = field
+	}
+	{
+		field, n, err := scale.DecodeStructSlice[nested.Struct](dec)
+		if err != nil {
+			return total, err
+		}
+		total += n
+		t.NestedStructSlice = field
+	}
+	return total, nil
+}
+
+func (t *MoreData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
 		n, err := scale.EncodeString(enc, string(t.NestedAlias))
 		if err != nil {
@@ -82,38 +121,7 @@ func (t *Data) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	return total, nil
 }
 
-func (t *Data) DecodeScale(dec *scale.Decoder) (total int, err error) {
-	{
-		field, n, err := scale.DecodeString(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.Str = string(field)
-	}
-	{
-		n, err := t.NestedStruct.DecodeScale(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	{
-		field, n, err := scale.DecodeOption[nested.Struct](dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.NestedStructPointer = field
-	}
-	{
-		field, n, err := scale.DecodeStructSlice[nested.Struct](dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.NestedStructSlice = field
-	}
+func (t *MoreData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
 		field, n, err := scale.DecodeString(dec)
 		if err != nil {

--- a/scalegen/runner/testdata/data_scale.go.empty
+++ b/scalegen/runner/testdata/data_scale.go.empty
@@ -13,3 +13,13 @@ func (t *Data) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 	return total, nil
 }
+
+func (t *MoreData) EncodeScale(enc *scale.Encoder) (total int, err error) {
+
+	return total, nil
+}
+
+func (t *MoreData) DecodeScale(dec *scale.Decoder) (total int, err error) {
+
+	return total, nil
+}


### PR DESCRIPTION
## Motivation
Closes #26

## Changes
Remove scale methods for deleted types to avoid compile errors on generate in a scale file.

