### PR TITLE
Avoid too many copies in string encoder/decoder

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"unsafe"
 )
 
 const (
@@ -355,10 +356,14 @@ func DecodeStringSliceWithLimit(d *Decoder, limit uint32) ([]string, int, error)
 	}
 	result := make([]string, 0, len(sliceOfByteSlices))
 	for i := range sliceOfByteSlices {
-		result = append(result, string(sliceOfByteSlices[i]))
+		result = append(result, byteSliceToString(sliceOfByteSlices[i]))
 	}
 
 	return result, n, nil
+}
+
+func byteSliceToString(bs []byte) string {
+	return *(*string)(unsafe.Pointer(&bs))
 }
 
 func DecodeStructArray[V any, H DecodablePtr[V]](d *Decoder, value []V) (int, error) {

--- a/decoder.go
+++ b/decoder.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"unsafe"
 )
 
 const (
@@ -356,7 +355,7 @@ func DecodeStringSliceWithLimit(d *Decoder, limit uint32) ([]string, int, error)
 	}
 	result := make([]string, 0, len(sliceOfByteSlices))
 	for i := range sliceOfByteSlices {
-		result = append(result, *(*string)(unsafe.Pointer(&sliceOfByteSlices[i])))
+		result = append(result, BytesToString(sliceOfByteSlices[i]))
 	}
 
 	return result, n, nil

--- a/decoder.go
+++ b/decoder.go
@@ -356,14 +356,10 @@ func DecodeStringSliceWithLimit(d *Decoder, limit uint32) ([]string, int, error)
 	}
 	result := make([]string, 0, len(sliceOfByteSlices))
 	for i := range sliceOfByteSlices {
-		result = append(result, byteSliceToString(sliceOfByteSlices[i]))
+		result = append(result, *(*string)(unsafe.Pointer(&sliceOfByteSlices[i])))
 	}
 
 	return result, n, nil
-}
-
-func byteSliceToString(bs []byte) string {
-	return *(*string)(unsafe.Pointer(&bs))
 }
 
 func DecodeStructArray[V any, H DecodablePtr[V]](d *Decoder, value []V) (int, error) {

--- a/decoder.go
+++ b/decoder.go
@@ -355,7 +355,7 @@ func DecodeStringSliceWithLimit(d *Decoder, limit uint32) ([]string, int, error)
 	}
 	result := make([]string, 0, len(sliceOfByteSlices))
 	for i := range sliceOfByteSlices {
-		result = append(result, BytesToString(sliceOfByteSlices[i]))
+		result = append(result, bytesToString(sliceOfByteSlices[i]))
 	}
 
 	return result, n, nil

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -40,6 +40,8 @@ func testEncode(tb testing.TB, value any) []byte {
 		_, err = EncodeByteSlice(enc, val)
 	case string:
 		_, err = EncodeString(enc, val)
+	case []string:
+		_, err = EncodeStringSlice(enc, val)
 	}
 	require.NoError(tb, err)
 	return buf.Bytes()
@@ -64,6 +66,8 @@ func expectEqual(tb testing.TB, value any, r io.Reader) {
 		rst, _, err = DecodeByteSlice(dec)
 	case string:
 		rst, _, err = DecodeString(dec)
+	case []string:
+		rst, _, err = DecodeStringSlice(dec)
 	}
 	require.NoError(tb, err)
 	require.Equal(tb, value, rst)
@@ -97,6 +101,10 @@ func TestReadFull(t *testing.T) {
 		{
 			desc:   "string",
 			expect: "dsa1232131312dsada123312",
+		},
+		{
+			desc:   "string slice",
+			expect: []string{"qwe123", "dsa456"},
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/encoder.go
+++ b/encoder.go
@@ -79,7 +79,7 @@ func EncodeStringWithLimit(e *Encoder, value string, limit uint32) (int, error) 
 		return total + n, nil
 	}
 
-	return EncodeByteSliceWithLimit(e, []byte(value), limit)
+	return EncodeByteSliceWithLimit(e, StringToBytes(value), limit)
 }
 
 func EncodeStructSlice[V any, H EncodablePtr[V]](e *Encoder, value []V) (int, error) {
@@ -127,7 +127,7 @@ func EncodeStringSlice(e *Encoder, value []string) (int, error) {
 func EncodeStringSliceWithLimit(e *Encoder, value []string, limit uint32) (int, error) {
 	valueToBytes := make([][]byte, 0, len(value))
 	for i := range value {
-		valueToBytes = append(valueToBytes, []byte(value[i]))
+		valueToBytes = append(valueToBytes, StringToBytes(value[i]))
 	}
 	return EncodeSliceOfByteSliceWithLimit(e, valueToBytes, limit)
 }

--- a/encoder.go
+++ b/encoder.go
@@ -79,7 +79,7 @@ func EncodeStringWithLimit(e *Encoder, value string, limit uint32) (int, error) 
 		return total + n, nil
 	}
 
-	return EncodeByteSliceWithLimit(e, StringToBytes(value), limit)
+	return EncodeByteSliceWithLimit(e, stringToBytes(value), limit)
 }
 
 func EncodeStructSlice[V any, H EncodablePtr[V]](e *Encoder, value []V) (int, error) {
@@ -127,7 +127,7 @@ func EncodeStringSlice(e *Encoder, value []string) (int, error) {
 func EncodeStringSliceWithLimit(e *Encoder, value []string, limit uint32) (int, error) {
 	valueToBytes := make([][]byte, 0, len(value))
 	for i := range value {
-		valueToBytes = append(valueToBytes, StringToBytes(value[i]))
+		valueToBytes = append(valueToBytes, stringToBytes(value[i]))
 	}
 	return EncodeSliceOfByteSliceWithLimit(e, valueToBytes, limit)
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,0 +1,37 @@
+package scale
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func BenchmarkEncodeStrings_WithStringWriter(b *testing.B) {
+
+	// strings.Builder implements the io.StringWriter interface.
+	var buf strings.Builder
+	enc := NewEncoder(&buf)
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		EncodeString(enc, "Hello World")
+	}
+	b.StopTimer()
+
+	_ = buf.Len() // avoid optimizations by compiler
+}
+
+func BenchmarkEncodeStrings_WithWriterForStrings(b *testing.B) {
+
+	// bytes.Buffer does not implement the io.StringWriter interface.
+	var buf bytes.Buffer
+	enc := NewEncoder(&buf)
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		EncodeString(enc, "Hello World")
+	}
+	b.StopTimer()
+
+	_ = buf.Len() // avoid optimizations by compiler
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -2,13 +2,24 @@ package scale
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 )
 
+type customBuffer struct {
+	buf bytes.Buffer
+}
+
+func (c *customBuffer) Write(b []byte) (int, error) {
+	return c.buf.Write(b)
+}
+
+func (c *customBuffer) Len() int {
+	return c.buf.Len()
+}
+
 func BenchmarkEncodeStrings_WithStringWriter(b *testing.B) {
-	// strings.Builder implements the io.StringWriter interface.
-	var buf strings.Builder
+	// bytes.Buffer implements the io.StringWriter interface.
+	var buf bytes.Buffer
 	enc := NewEncoder(&buf)
 
 	b.StartTimer()
@@ -21,8 +32,8 @@ func BenchmarkEncodeStrings_WithStringWriter(b *testing.B) {
 }
 
 func BenchmarkEncodeStrings_WithWriterForStrings(b *testing.B) {
-	// bytes.Buffer does not implement the io.StringWriter interface.
-	var buf bytes.Buffer
+	// CustomBuffer does not implement the io.StringWriter interface.
+	var buf customBuffer
 	enc := NewEncoder(&buf)
 
 	b.StartTimer()

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -16,6 +16,8 @@ func BenchmarkEncodeStrings_WithStringWriter(b *testing.B) {
 		EncodeString(enc, "Hello World")
 	}
 	b.StopTimer()
+
+	b.Log(buf.Len())
 }
 
 func BenchmarkEncodeStrings_WithWriterForStrings(b *testing.B) {
@@ -28,4 +30,6 @@ func BenchmarkEncodeStrings_WithWriterForStrings(b *testing.B) {
 		EncodeString(enc, "Hello World")
 	}
 	b.StopTimer()
+
+	b.Log(buf.Len())
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func BenchmarkEncodeStrings_WithStringWriter(b *testing.B) {
-
 	// strings.Builder implements the io.StringWriter interface.
 	var buf strings.Builder
 	enc := NewEncoder(&buf)
@@ -17,12 +16,9 @@ func BenchmarkEncodeStrings_WithStringWriter(b *testing.B) {
 		EncodeString(enc, "Hello World")
 	}
 	b.StopTimer()
-
-	_ = buf.Len() // avoid optimizations by compiler
 }
 
 func BenchmarkEncodeStrings_WithWriterForStrings(b *testing.B) {
-
 	// bytes.Buffer does not implement the io.StringWriter interface.
 	var buf bytes.Buffer
 	enc := NewEncoder(&buf)
@@ -32,6 +28,4 @@ func BenchmarkEncodeStrings_WithWriterForStrings(b *testing.B) {
 		EncodeString(enc, "Hello World")
 	}
 	b.StopTimer()
-
-	_ = buf.Len() // avoid optimizations by compiler
 }

--- a/unsafe.go
+++ b/unsafe.go
@@ -5,7 +5,10 @@ import (
 	"unsafe"
 )
 
-func StringToBytes(s string) []byte {
+// stringToBytes converts a string to a byte slice without copying the underlying data.
+// IMPORTANT: The returned byte slice must not be modified!
+// This is a low-level function and should be used carefully.
+func stringToBytes(s string) []byte {
 	if s == "" {
 		return nil
 	}
@@ -17,7 +20,9 @@ func StringToBytes(s string) []byte {
 	return (*[max]byte)(unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&s)).Data))[:len(s):len(s)]
 }
 
-func BytesToString(b []byte) string {
+// bytesToString converts a byte slice to a string without copying the underlying data.
+// This is a low-level function and should be used carefully.
+func bytesToString(b []byte) string {
 	if len(b) == 0 {
 		return ""
 	}

--- a/unsafe.go
+++ b/unsafe.go
@@ -1,0 +1,26 @@
+package scale
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func StringToBytes(s string) []byte {
+	if s == "" {
+		return nil
+	}
+
+	const max = 0x7fff0000
+	if len(s) > max {
+		panic("string too long")
+	}
+	return (*[max]byte)(unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&s)).Data))[:len(s):len(s)]
+}
+
+func BytesToString(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+
+	return *(*string)(unsafe.Pointer(&b))
+}

--- a/unsafe_test.go
+++ b/unsafe_test.go
@@ -10,7 +10,7 @@ func Benchmark_UnsafeBytesToString(b *testing.B) {
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		out = BytesToString(in)
+		out = bytesToString(in)
 		// assert.Equal(b, "Hello World", out)
 	}
 	b.StopTimer()
@@ -36,7 +36,7 @@ func Benchmark_UnsafeStringToBytes(b *testing.B) {
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		out = StringToBytes(in)
+		out = stringToBytes(in)
 		// assert.Equal(b, []byte("Hello World"), out)
 	}
 	b.StopTimer()

--- a/unsafe_test.go
+++ b/unsafe_test.go
@@ -6,48 +6,52 @@ import (
 
 func Benchmark_UnsafeBytesToString(b *testing.B) {
 	in := []byte("Hello World")
+	var out string
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		out := BytesToString(in)
+		out = BytesToString(in)
 		// assert.Equal(b, "Hello World", out)
-		_ = out
 	}
 	b.StopTimer()
+	b.Log(out)
 }
 
 func Benchmark_SafeBytesToString(b *testing.B) {
 	in := []byte("Hello World")
+	var out string
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		out := string(in)
+		out = string(in)
 		// assert.Equal(b, "Hello World", out)
-		_ = out
 	}
 	b.StopTimer()
+	b.Log(out)
 }
 
 func Benchmark_UnsafeStringToBytes(b *testing.B) {
 	in := "Hello World"
+	var out []byte
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		out := StringToBytes(in)
+		out = StringToBytes(in)
 		// assert.Equal(b, []byte("Hello World"), out)
-		_ = out
 	}
 	b.StopTimer()
+	b.Log(string(out))
 }
 
 func Benchmark_SafeStringToBytes(b *testing.B) {
 	in := "Hello World"
+	var out []byte
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		out := []byte(in)
+		out = []byte(in)
 		// assert.Equal(b, []byte("Hello World"), out)
-		_ = out
 	}
 	b.StopTimer()
+	b.Log(string(out))
 }

--- a/unsafe_test.go
+++ b/unsafe_test.go
@@ -1,0 +1,53 @@
+package scale
+
+import (
+	"testing"
+)
+
+func Benchmark_UnsafeBytesToString(b *testing.B) {
+	in := []byte("Hello World")
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		out := BytesToString(in)
+		// assert.Equal(b, "Hello World", out)
+		_ = out
+	}
+	b.StopTimer()
+}
+
+func Benchmark_SafeBytesToString(b *testing.B) {
+	in := []byte("Hello World")
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		out := string(in)
+		// assert.Equal(b, "Hello World", out)
+		_ = out
+	}
+	b.StopTimer()
+}
+
+func Benchmark_UnsafeStringToBytes(b *testing.B) {
+	in := "Hello World"
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		out := StringToBytes(in)
+		// assert.Equal(b, []byte("Hello World"), out)
+		_ = out
+	}
+	b.StopTimer()
+}
+
+func Benchmark_SafeStringToBytes(b *testing.B) {
+	in := "Hello World"
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		out := []byte(in)
+		// assert.Equal(b, []byte("Hello World"), out)
+		_ = out
+	}
+	b.StopTimer()
+}


### PR DESCRIPTION
Closes [#12](https://github.com/spacemeshos/go-scale/issues/12)