### PR TITLE
Enforce max tags on all variable length types

### DIFF
--- a/examples/bytes.go
+++ b/examples/bytes.go
@@ -15,13 +15,9 @@ type Bytes64 struct {
 }
 
 type Slice struct {
-	Value []byte
-}
-
-type SliceWithLimit struct {
 	Value []byte `scale:"max=10"`
 }
 
-type SliceOfByteSliceWithLimit struct {
-	Value [][]byte
+type SliceOfByteSlice struct {
+	Value [][]byte `scale:"max=10"`
 }

--- a/examples/bytes.go
+++ b/examples/bytes.go
@@ -17,7 +17,3 @@ type Bytes64 struct {
 type Slice struct {
 	Value []byte `scale:"max=10"`
 }
-
-type SliceOfByteSlice struct {
-	Value [][]byte `scale:"max=10"`
-}

--- a/examples/bytes_scale.go
+++ b/examples/bytes_scale.go
@@ -75,29 +75,6 @@ func (t *Bytes64) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *Slice) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeByteSlice(enc, t.Value)
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	return total, nil
-}
-
-func (t *Slice) DecodeScale(dec *scale.Decoder) (total int, err error) {
-	{
-		field, n, err := scale.DecodeByteSlice(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.Value = field
-	}
-	return total, nil
-}
-
-func (t *SliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, err error) {
-	{
 		n, err := scale.EncodeByteSliceWithLimit(enc, t.Value, 10)
 		if err != nil {
 			return total, err
@@ -107,7 +84,7 @@ func (t *SliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, err error) 
 	return total, nil
 }
 
-func (t *SliceWithLimit) DecodeScale(dec *scale.Decoder) (total int, err error) {
+func (t *Slice) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
 		field, n, err := scale.DecodeByteSliceWithLimit(dec, 10)
 		if err != nil {
@@ -119,9 +96,9 @@ func (t *SliceWithLimit) DecodeScale(dec *scale.Decoder) (total int, err error) 
 	return total, nil
 }
 
-func (t *SliceOfByteSliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, err error) {
+func (t *SliceOfByteSlice) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeSliceOfByteSlice(enc, t.Value)
+		n, err := scale.EncodeSliceOfByteSliceWithLimit(enc, t.Value, 10)
 		if err != nil {
 			return total, err
 		}
@@ -130,9 +107,9 @@ func (t *SliceOfByteSliceWithLimit) EncodeScale(enc *scale.Encoder) (total int, 
 	return total, nil
 }
 
-func (t *SliceOfByteSliceWithLimit) DecodeScale(dec *scale.Decoder) (total int, err error) {
+func (t *SliceOfByteSlice) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeSliceOfByteSlice(dec)
+		field, n, err := scale.DecodeSliceOfByteSliceWithLimit(dec, 10)
 		if err != nil {
 			return total, err
 		}

--- a/examples/bytes_scale.go
+++ b/examples/bytes_scale.go
@@ -95,26 +95,3 @@ func (t *Slice) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	}
 	return total, nil
 }
-
-func (t *SliceOfByteSlice) EncodeScale(enc *scale.Encoder) (total int, err error) {
-	{
-		n, err := scale.EncodeSliceOfByteSliceWithLimit(enc, t.Value, 10)
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	return total, nil
-}
-
-func (t *SliceOfByteSlice) DecodeScale(dec *scale.Decoder) (total int, err error) {
-	{
-		field, n, err := scale.DecodeSliceOfByteSliceWithLimit(dec, 10)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.Value = field
-	}
-	return total, nil
-}

--- a/examples/bytes_test.go
+++ b/examples/bytes_test.go
@@ -22,18 +22,10 @@ func FuzzBytesSliceSafety(f *testing.F) {
 	tester.FuzzSafety[Slice](f)
 }
 
-func FuzzBytesSliceWithLimitConsistency(f *testing.F) {
-	tester.FuzzConsistency[SliceWithLimit](f)
-}
-
-func FuzzBytesSliceWithLimitSafety(f *testing.F) {
-	tester.FuzzSafety[SliceWithLimit](f)
-}
-
 func FuzzSliceOfByteSliceWithLimitConsistency(f *testing.F) {
-	tester.FuzzConsistency[SliceOfByteSliceWithLimit](f)
+	tester.FuzzConsistency[SliceOfByteSlice](f)
 }
 
 func FuzzSliceOfByteSliceWithLimitSafety(f *testing.F) {
-	tester.FuzzSafety[SliceOfByteSliceWithLimit](f)
+	tester.FuzzSafety[SliceOfByteSlice](f)
 }

--- a/examples/bytes_test.go
+++ b/examples/bytes_test.go
@@ -21,11 +21,3 @@ func FuzzBytesSliceConsistency(f *testing.F) {
 func FuzzBytesSliceSafety(f *testing.F) {
 	tester.FuzzSafety[Slice](f)
 }
-
-func FuzzSliceOfByteSliceWithLimitConsistency(f *testing.F) {
-	tester.FuzzConsistency[SliceOfByteSlice](f)
-}
-
-func FuzzSliceOfByteSliceWithLimitSafety(f *testing.F) {
-	tester.FuzzSafety[SliceOfByteSlice](f)
-}

--- a/examples/errors/byteslice.go
+++ b/examples/errors/byteslice.go
@@ -1,0 +1,5 @@
+package errors
+
+type Slice struct {
+	Value []byte
+}

--- a/examples/errors/byteslice.json
+++ b/examples/errors/byteslice.json
@@ -1,0 +1,5 @@
+{
+    "errors": [
+        "slices must have max scale tag"
+    ]
+}

--- a/examples/errors/byteslice.json
+++ b/examples/errors/byteslice.json
@@ -1,5 +1,5 @@
 {
-    "errors": [
+    "Errors": [
         "slices must have max scale tag"
     ]
 }

--- a/examples/errors/slicebyteslice.go
+++ b/examples/errors/slicebyteslice.go
@@ -1,0 +1,5 @@
+package errors
+
+type SliceOfByteSlice struct {
+	Value [][]byte
+}

--- a/examples/errors/slicebyteslice.json
+++ b/examples/errors/slicebyteslice.json
@@ -1,0 +1,5 @@
+{
+    "errors": [
+        "slices must have max scale tag"
+    ]
+}

--- a/examples/errors/slicebyteslice.json
+++ b/examples/errors/slicebyteslice.json
@@ -1,5 +1,5 @@
 {
-    "errors": [
-        "slices must have max scale tag"
+    "Errors": [
+        "nested slices are not supported"
     ]
 }

--- a/examples/errors/stringalias.go
+++ b/examples/errors/stringalias.go
@@ -1,0 +1,7 @@
+package errors
+
+type StringAlias string
+
+type TypeAlias struct {
+	Value StringAlias
+}

--- a/examples/errors/stringalias.json
+++ b/examples/errors/stringalias.json
@@ -1,5 +1,5 @@
 {
-    "errors": [
-        "slices must have max scale tag"
+    "Errors": [
+        "strings must have max scale tag"
     ]
 }

--- a/examples/errors/stringalias.json
+++ b/examples/errors/stringalias.json
@@ -1,0 +1,5 @@
+{
+    "errors": [
+        "slices must have max scale tag"
+    ]
+}

--- a/examples/errors/strings.go
+++ b/examples/errors/strings.go
@@ -1,0 +1,5 @@
+package errors
+
+type StringStruct struct {
+	Value string
+}

--- a/examples/errors/strings.json
+++ b/examples/errors/strings.json
@@ -1,5 +1,5 @@
 {
-    "errors": [
-        "slices must have max scale tag"
+    "Errors": [
+        "strings must have max scale tag"
     ]
 }

--- a/examples/errors/strings.json
+++ b/examples/errors/strings.json
@@ -1,0 +1,5 @@
+{
+    "errors": [
+        "slices must have max scale tag"
+    ]
+}

--- a/examples/errors/stringsslice.go
+++ b/examples/errors/stringsslice.go
@@ -1,0 +1,5 @@
+package errors
+
+type StringSlice struct {
+	Value []string
+}

--- a/examples/errors/stringsslice.json
+++ b/examples/errors/stringsslice.json
@@ -1,5 +1,5 @@
 {
-    "errors": [
-        "slices must have max scale tag"
+    "Errors": [
+        "string slices are not supported"
     ]
 }

--- a/examples/errors/stringsslice.json
+++ b/examples/errors/stringsslice.json
@@ -1,0 +1,5 @@
+{
+    "errors": [
+        "slices must have max scale tag"
+    ]
+}

--- a/examples/errors/structslice.go
+++ b/examples/errors/structslice.go
@@ -1,0 +1,5 @@
+package errors
+
+type Ex2 struct {
+	Slice []Ex2
+}

--- a/examples/errors/structslice.json
+++ b/examples/errors/structslice.json
@@ -1,0 +1,5 @@
+{
+    "errors": [
+        "slices must have max scale tag"
+    ]
+}

--- a/examples/errors/structslice.json
+++ b/examples/errors/structslice.json
@@ -1,5 +1,5 @@
 {
-    "errors": [
+    "Errors": [
         "slices must have max scale tag"
     ]
 }

--- a/examples/ex2.go
+++ b/examples/ex2.go
@@ -3,7 +3,7 @@ package examples
 //go:generate scalegen
 
 type Ex2 struct {
-	Slice []Ex2
+	Slice []Ex2 `scale:"max=2"`
 	Array [5]Smth
 }
 

--- a/examples/ex2_scale.go
+++ b/examples/ex2_scale.go
@@ -9,7 +9,7 @@ import (
 
 func (t *Ex2) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSlice(enc, t.Slice)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Slice, 2)
 		if err != nil {
 			return total, err
 		}
@@ -27,7 +27,7 @@ func (t *Ex2) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Ex2) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSlice[Ex2](dec)
+		field, n, err := scale.DecodeStructSliceWithLimit[Ex2](dec, 2)
 		if err != nil {
 			return total, err
 		}

--- a/examples/nested_struct_slice_with_import.go
+++ b/examples/nested_struct_slice_with_import.go
@@ -5,5 +5,5 @@ import "github.com/spacemeshos/go-scale/examples/nested"
 //go:generate scalegen
 
 type NestedStructSlice struct {
-	Value []nested.Struct
+	Value []nested.Struct `scale:"max=5"`
 }

--- a/examples/nested_struct_slice_with_import_scale.go
+++ b/examples/nested_struct_slice_with_import_scale.go
@@ -10,7 +10,7 @@ import (
 
 func (t *NestedStructSlice) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeStructSlice(enc, t.Value)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.Value, 5)
 		if err != nil {
 			return total, err
 		}
@@ -21,7 +21,7 @@ func (t *NestedStructSlice) EncodeScale(enc *scale.Encoder) (total int, err erro
 
 func (t *NestedStructSlice) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeStructSlice[nested.Struct](dec)
+		field, n, err := scale.DecodeStructSliceWithLimit[nested.Struct](dec, 5)
 		if err != nil {
 			return total, err
 		}

--- a/examples/nested_type_alias_with_import.go
+++ b/examples/nested_type_alias_with_import.go
@@ -5,5 +5,5 @@ import "github.com/spacemeshos/go-scale/examples/nested"
 //go:generate scalegen
 
 type NestedTypeAliasWithImport struct {
-	Value nested.StringAlias
+	Value nested.StringAlias `scale:"max=20"`
 }

--- a/examples/nested_type_alias_with_import_scale.go
+++ b/examples/nested_type_alias_with_import_scale.go
@@ -10,7 +10,7 @@ import (
 
 func (t *NestedTypeAliasWithImport) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeString(enc, string(t.Value))
+		n, err := scale.EncodeStringWithLimit(enc, string(t.Value), 20)
 		if err != nil {
 			return total, err
 		}
@@ -21,7 +21,7 @@ func (t *NestedTypeAliasWithImport) EncodeScale(enc *scale.Encoder) (total int, 
 
 func (t *NestedTypeAliasWithImport) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeString(dec)
+		field, n, err := scale.DecodeStringWithLimit(dec, 20)
 		if err != nil {
 			return total, err
 		}

--- a/examples/spend.go
+++ b/examples/spend.go
@@ -8,7 +8,7 @@ type Spend struct {
 }
 
 type SpendBody struct {
-	Adress   [20]byte
+	Address  [20]byte
 	Selector uint8
 	Payload  SpendPayload
 }

--- a/examples/spend_scale.go
+++ b/examples/spend_scale.go
@@ -46,7 +46,7 @@ func (t *Spend) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *SpendBody) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeByteArray(enc, t.Adress[:])
+		n, err := scale.EncodeByteArray(enc, t.Address[:])
 		if err != nil {
 			return total, err
 		}
@@ -71,7 +71,7 @@ func (t *SpendBody) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *SpendBody) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		n, err := scale.DecodeByteArray(dec, t.Adress[:])
+		n, err := scale.DecodeByteArray(dec, t.Address[:])
 		if err != nil {
 			return total, err
 		}

--- a/examples/string.go
+++ b/examples/string.go
@@ -6,10 +6,6 @@ type StructWithString struct {
 	Value string `scale:"max=3"`
 }
 
-type StructWithStringSliceAndLimit struct {
-	Value []string `scale:"max=3"`
-}
-
 type StringAlias string
 
 type StructWithStringAlias struct {

--- a/examples/string.go
+++ b/examples/string.go
@@ -3,10 +3,6 @@ package examples
 //go:generate scalegen
 
 type StructWithString struct {
-	Value string
-}
-
-type StructWithStringLimit struct {
 	Value string `scale:"max=3"`
 }
 
@@ -17,9 +13,5 @@ type StructWithStringSliceAndLimit struct {
 type StringAlias string
 
 type StructWithStringAlias struct {
-	Value StringAlias
-}
-
-type StructWithStringAliasAndLimit struct {
 	Value StringAlias `scale:"max=3"`
 }

--- a/examples/string_scale.go
+++ b/examples/string_scale.go
@@ -30,29 +30,6 @@ func (t *StructWithString) DecodeScale(dec *scale.Decoder) (total int, err error
 	return total, nil
 }
 
-func (t *StructWithStringSliceAndLimit) EncodeScale(enc *scale.Encoder) (total int, err error) {
-	{
-		n, err := scale.EncodeStringSliceWithLimit(enc, t.Value, 3)
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	return total, nil
-}
-
-func (t *StructWithStringSliceAndLimit) DecodeScale(dec *scale.Decoder) (total int, err error) {
-	{
-		field, n, err := scale.DecodeStringSliceWithLimit(dec, 3)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.Value = field
-	}
-	return total, nil
-}
-
 func (t *StructWithStringAlias) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
 		n, err := scale.EncodeStringWithLimit(enc, string(t.Value), 3)

--- a/examples/string_scale.go
+++ b/examples/string_scale.go
@@ -9,29 +9,6 @@ import (
 
 func (t *StructWithString) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeString(enc, string(t.Value))
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	return total, nil
-}
-
-func (t *StructWithString) DecodeScale(dec *scale.Decoder) (total int, err error) {
-	{
-		field, n, err := scale.DecodeString(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.Value = string(field)
-	}
-	return total, nil
-}
-
-func (t *StructWithStringLimit) EncodeScale(enc *scale.Encoder) (total int, err error) {
-	{
 		n, err := scale.EncodeStringWithLimit(enc, string(t.Value), 3)
 		if err != nil {
 			return total, err
@@ -41,7 +18,7 @@ func (t *StructWithStringLimit) EncodeScale(enc *scale.Encoder) (total int, err 
 	return total, nil
 }
 
-func (t *StructWithStringLimit) DecodeScale(dec *scale.Decoder) (total int, err error) {
+func (t *StructWithString) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
 		field, n, err := scale.DecodeStringWithLimit(dec, 3)
 		if err != nil {
@@ -78,29 +55,6 @@ func (t *StructWithStringSliceAndLimit) DecodeScale(dec *scale.Decoder) (total i
 
 func (t *StructWithStringAlias) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeString(enc, string(t.Value))
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	return total, nil
-}
-
-func (t *StructWithStringAlias) DecodeScale(dec *scale.Decoder) (total int, err error) {
-	{
-		field, n, err := scale.DecodeString(dec)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.Value = StringAlias(field)
-	}
-	return total, nil
-}
-
-func (t *StructWithStringAliasAndLimit) EncodeScale(enc *scale.Encoder) (total int, err error) {
-	{
 		n, err := scale.EncodeStringWithLimit(enc, string(t.Value), 3)
 		if err != nil {
 			return total, err
@@ -110,7 +64,7 @@ func (t *StructWithStringAliasAndLimit) EncodeScale(enc *scale.Encoder) (total i
 	return total, nil
 }
 
-func (t *StructWithStringAliasAndLimit) DecodeScale(dec *scale.Decoder) (total int, err error) {
+func (t *StructWithStringAlias) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
 		field, n, err := scale.DecodeStringWithLimit(dec, 3)
 		if err != nil {

--- a/examples/string_test.go
+++ b/examples/string_test.go
@@ -14,14 +14,6 @@ func FuzzStructWithStringSafety(f *testing.F) {
 	tester.FuzzSafety[StructWithString](f)
 }
 
-func FuzzStructWithStringSliceAndLimitConsistency(f *testing.F) {
-	tester.FuzzConsistency[StructWithStringSliceAndLimit](f)
-}
-
-func FuzzStructWithStringSliceAndLimitSafety(f *testing.F) {
-	tester.FuzzSafety[StructWithStringSliceAndLimit](f)
-}
-
 func FuzzStructWithStringAliasConsistency(f *testing.F) {
 	tester.FuzzConsistency[StructWithStringAlias](f)
 }

--- a/examples/string_test.go
+++ b/examples/string_test.go
@@ -14,14 +14,6 @@ func FuzzStructWithStringSafety(f *testing.F) {
 	tester.FuzzSafety[StructWithString](f)
 }
 
-func FuzzStructWithStringLimitConsistency(f *testing.F) {
-	tester.FuzzConsistency[StructWithStringLimit](f)
-}
-
-func FuzzStructWithStringLimitSafety(f *testing.F) {
-	tester.FuzzSafety[StructWithStringLimit](f)
-}
-
 func FuzzStructWithStringSliceAndLimitConsistency(f *testing.F) {
 	tester.FuzzConsistency[StructWithStringSliceAndLimit](f)
 }
@@ -36,12 +28,4 @@ func FuzzStructWithStringAliasConsistency(f *testing.F) {
 
 func FuzzStructWithStringAliasSafety(f *testing.F) {
 	tester.FuzzSafety[StructWithStringAlias](f)
-}
-
-func FuzzStructWithStringAliasAndLimitConsistency(f *testing.F) {
-	tester.FuzzConsistency[StructWithStringAliasAndLimit](f)
-}
-
-func FuzzStructWithStringAliasAndLimitSafety(f *testing.F) {
-	tester.FuzzSafety[StructWithStringAliasAndLimit](f)
 }

--- a/generate.go
+++ b/generate.go
@@ -285,15 +285,15 @@ func getScaleType(parentType reflect.Type, field reflect.StructField) (scaleType
 		if err != nil {
 			return scaleType{}, fmt.Errorf("scale tag has incorrect max value: %w", err)
 		}
-		if maxElements > 0 {
-			return scaleType{
-				Name:           "StringWithLimit",
-				Args:           fmt.Sprintf(", %d", maxElements),
-				EncodeModifier: "string",
-				DecodeModifier: decodeModifier,
-			}, nil
+		if maxElements == 0 {
+			return scaleType{}, fmt.Errorf("strings must have max scale tag")
 		}
-		return scaleType{Name: "String", EncodeModifier: "string", DecodeModifier: decodeModifier}, nil
+		return scaleType{
+			Name:           "StringWithLimit",
+			Args:           fmt.Sprintf(", %d", maxElements),
+			EncodeModifier: "string",
+			DecodeModifier: decodeModifier,
+		}, nil
 	case reflect.Uint8:
 		return scaleType{Name: "Compact8", EncodeModifier: "uint8", DecodeModifier: decodeModifier}, nil
 	case reflect.Uint16:
@@ -311,29 +311,22 @@ func getScaleType(parentType reflect.Type, field reflect.StructField) (scaleType
 		if err != nil {
 			return scaleType{}, fmt.Errorf("scale tag has incorrect max value: %w", err)
 		}
+		if maxElements == 0 {
+			return scaleType{}, fmt.Errorf("slices must have max scale tag")
+		}
 		// [][]byte
 		if field.Type.Elem().Kind() == reflect.Slice && field.Type.Elem().Elem().Kind() == reflect.Uint8 {
-			if maxElements > 0 {
-				return scaleType{Name: "SliceOfByteSliceWithLimit", Args: fmt.Sprintf(", %d", maxElements)}, nil
-			}
-			return scaleType{Name: "SliceOfByteSlice"}, nil
+			// TODO(mafa): check how to handle length of slice in slice
+			return scaleType{Name: "SliceOfByteSliceWithLimit", Args: fmt.Sprintf(", %d", maxElements)}, nil
 		}
 		if field.Type.Elem().Kind() == reflect.String {
-			if maxElements > 0 {
-				return scaleType{Name: "StringSliceWithLimit", Args: fmt.Sprintf(", %d", maxElements)}, nil
-			}
-			return scaleType{Name: "StringSlice"}, nil
+			// TODO(mafa): check how to handle length of string in slice
+			return scaleType{Name: "StringSliceWithLimit", Args: fmt.Sprintf(", %d", maxElements)}, nil
 		}
 		if field.Type.Elem().Kind() == reflect.Uint8 {
-			if maxElements > 0 {
-				return scaleType{Name: "ByteSliceWithLimit", Args: fmt.Sprintf(", %d", maxElements)}, nil
-			}
-			return scaleType{Name: "ByteSlice"}, nil
+			return scaleType{Name: "ByteSliceWithLimit", Args: fmt.Sprintf(", %d", maxElements)}, nil
 		}
-		if maxElements > 0 {
-			return scaleType{Name: "StructSliceWithLimit", Args: fmt.Sprintf(", %d", maxElements)}, nil
-		}
-		return scaleType{Name: "StructSlice"}, nil
+		return scaleType{Name: "StructSliceWithLimit", Args: fmt.Sprintf(", %d", maxElements)}, nil
 	case reflect.Array:
 		if field.Type.Elem().Kind() == reflect.Uint8 {
 			return scaleType{Name: "ByteArray"}, nil
@@ -373,7 +366,7 @@ func getMaxElements(tag reflect.StructTag) (uint32, error) {
 	}
 	maxElements, err := strconv.Atoi(maxElementsStr)
 	if err != nil {
-		return 0, fmt.Errorf("failed parsing max value: %w", err)
+		return 0, fmt.Errorf("parsing max value: %w", err)
 	}
 	return uint32(maxElements), nil
 }
@@ -408,7 +401,7 @@ func executeAction(action int, w io.Writer, gc *genContext, tc *typeContext) err
 
 		scaleType, err := getScaleType(typ, field)
 		if err != nil {
-			return fmt.Errorf("failed getting scale type: %w", err)
+			return fmt.Errorf("getting scale type: %w", err)
 		}
 
 		tctx := &typeContext{

--- a/scalegen/runner/runner_test.go
+++ b/scalegen/runner/runner_test.go
@@ -80,14 +80,14 @@ func TestExampleErrors(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := struct {
-				Error []string
+				Errors []string
 			}{}
 			json.NewDecoder(ref).Decode(&expected)
 
 			stderr := &bytes.Buffer{}
 			require.Error(t, RunGenerate(in, out, nil, withStderr(stderr)))
 
-			for _, err := range expected.Error {
+			for _, err := range expected.Errors {
 				require.Contains(t, stderr.String(), err)
 			}
 		})

--- a/scalegen/runner/testdata/data.go
+++ b/scalegen/runner/testdata/data.go
@@ -5,17 +5,17 @@ import "github.com/spacemeshos/go-scale/examples/nested"
 //go:generate scalegen
 
 type Data struct {
-	Str                 string
+	Str                 string `scale:"max=20"`
 	NestedStruct        nested.Struct
 	NestedStructPointer *nested.Struct
-	NestedStructSlice   []nested.Struct
+	NestedStructSlice   []nested.Struct `scale:"max=5"`
 }
 
 type MoreData struct {
-	NestedAlias       nested.StringAlias
-	StrSlice          []string
+	NestedAlias       nested.StringAlias `scale:"max=20"`
+	StrSlice          []string           `scale:"max=5"`
 	ByteArray         [20]byte
-	ByteSlice         []byte
-	SliceOfByteSlices [][]byte
+	ByteSlice         []byte   `scale:"max=20"`
+	SliceOfByteSlices [][]byte `scale:"max=10"`
 	Uint64            uint64
 }

--- a/scalegen/runner/testdata/data.go
+++ b/scalegen/runner/testdata/data.go
@@ -11,11 +11,14 @@ type Data struct {
 	NestedStructSlice   []nested.Struct `scale:"max=5"`
 }
 
+type Name struct {
+	Value string `scale:"max=20"`
+}
+
 type MoreData struct {
-	NestedAlias       nested.StringAlias `scale:"max=20"`
-	StrSlice          []string           `scale:"max=5"`
-	ByteArray         [20]byte
-	ByteSlice         []byte   `scale:"max=20"`
-	SliceOfByteSlices [][]byte `scale:"max=10"`
-	Uint64            uint64
+	NestedAlias nested.StringAlias `scale:"max=20"`
+	StrSlice    []Name             `scale:"max=5"`
+	ByteArray   [20]byte
+	ByteSlice   []byte `scale:"max=20"`
+	Uint64      uint64
 }

--- a/scalegen/runner/testdata/data_scale.go
+++ b/scalegen/runner/testdata/data_scale.go
@@ -75,6 +75,29 @@ func (t *Data) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	return total, nil
 }
 
+func (t *Name) EncodeScale(enc *scale.Encoder) (total int, err error) {
+	{
+		n, err := scale.EncodeStringWithLimit(enc, string(t.Value), 20)
+		if err != nil {
+			return total, err
+		}
+		total += n
+	}
+	return total, nil
+}
+
+func (t *Name) DecodeScale(dec *scale.Decoder) (total int, err error) {
+	{
+		field, n, err := scale.DecodeStringWithLimit(dec, 20)
+		if err != nil {
+			return total, err
+		}
+		total += n
+		t.Value = string(field)
+	}
+	return total, nil
+}
+
 func (t *MoreData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
 		n, err := scale.EncodeStringWithLimit(enc, string(t.NestedAlias), 20)
@@ -84,7 +107,7 @@ func (t *MoreData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeStringSliceWithLimit(enc, t.StrSlice, 5)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.StrSlice, 5)
 		if err != nil {
 			return total, err
 		}
@@ -99,13 +122,6 @@ func (t *MoreData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	}
 	{
 		n, err := scale.EncodeByteSliceWithLimit(enc, t.ByteSlice, 20)
-		if err != nil {
-			return total, err
-		}
-		total += n
-	}
-	{
-		n, err := scale.EncodeSliceOfByteSliceWithLimit(enc, t.SliceOfByteSlices, 10)
 		if err != nil {
 			return total, err
 		}
@@ -131,7 +147,7 @@ func (t *MoreData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.NestedAlias = nested.StringAlias(field)
 	}
 	{
-		field, n, err := scale.DecodeStringSliceWithLimit(dec, 5)
+		field, n, err := scale.DecodeStructSliceWithLimit[Name](dec, 5)
 		if err != nil {
 			return total, err
 		}
@@ -152,14 +168,6 @@ func (t *MoreData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		}
 		total += n
 		t.ByteSlice = field
-	}
-	{
-		field, n, err := scale.DecodeSliceOfByteSliceWithLimit(dec, 10)
-		if err != nil {
-			return total, err
-		}
-		total += n
-		t.SliceOfByteSlices = field
 	}
 	{
 		field, n, err := scale.DecodeCompact64(dec)

--- a/scalegen/runner/testdata/data_scale.go
+++ b/scalegen/runner/testdata/data_scale.go
@@ -10,7 +10,7 @@ import (
 
 func (t *Data) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeString(enc, string(t.Str))
+		n, err := scale.EncodeStringWithLimit(enc, string(t.Str), 20)
 		if err != nil {
 			return total, err
 		}
@@ -31,7 +31,7 @@ func (t *Data) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeStructSlice(enc, t.NestedStructSlice)
+		n, err := scale.EncodeStructSliceWithLimit(enc, t.NestedStructSlice, 5)
 		if err != nil {
 			return total, err
 		}
@@ -42,7 +42,7 @@ func (t *Data) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *Data) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeString(dec)
+		field, n, err := scale.DecodeStringWithLimit(dec, 20)
 		if err != nil {
 			return total, err
 		}
@@ -65,7 +65,7 @@ func (t *Data) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.NestedStructPointer = field
 	}
 	{
-		field, n, err := scale.DecodeStructSlice[nested.Struct](dec)
+		field, n, err := scale.DecodeStructSliceWithLimit[nested.Struct](dec, 5)
 		if err != nil {
 			return total, err
 		}
@@ -77,14 +77,14 @@ func (t *Data) DecodeScale(dec *scale.Decoder) (total int, err error) {
 
 func (t *MoreData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 	{
-		n, err := scale.EncodeString(enc, string(t.NestedAlias))
+		n, err := scale.EncodeStringWithLimit(enc, string(t.NestedAlias), 20)
 		if err != nil {
 			return total, err
 		}
 		total += n
 	}
 	{
-		n, err := scale.EncodeStringSlice(enc, t.StrSlice)
+		n, err := scale.EncodeStringSliceWithLimit(enc, t.StrSlice, 5)
 		if err != nil {
 			return total, err
 		}
@@ -98,14 +98,14 @@ func (t *MoreData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 		total += n
 	}
 	{
-		n, err := scale.EncodeByteSlice(enc, t.ByteSlice)
+		n, err := scale.EncodeByteSliceWithLimit(enc, t.ByteSlice, 20)
 		if err != nil {
 			return total, err
 		}
 		total += n
 	}
 	{
-		n, err := scale.EncodeSliceOfByteSlice(enc, t.SliceOfByteSlices)
+		n, err := scale.EncodeSliceOfByteSliceWithLimit(enc, t.SliceOfByteSlices, 10)
 		if err != nil {
 			return total, err
 		}
@@ -123,7 +123,7 @@ func (t *MoreData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 func (t *MoreData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	{
-		field, n, err := scale.DecodeString(dec)
+		field, n, err := scale.DecodeStringWithLimit(dec, 20)
 		if err != nil {
 			return total, err
 		}
@@ -131,7 +131,7 @@ func (t *MoreData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.NestedAlias = nested.StringAlias(field)
 	}
 	{
-		field, n, err := scale.DecodeStringSlice(dec)
+		field, n, err := scale.DecodeStringSliceWithLimit(dec, 5)
 		if err != nil {
 			return total, err
 		}
@@ -146,7 +146,7 @@ func (t *MoreData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		total += n
 	}
 	{
-		field, n, err := scale.DecodeByteSlice(dec)
+		field, n, err := scale.DecodeByteSliceWithLimit(dec, 20)
 		if err != nil {
 			return total, err
 		}
@@ -154,7 +154,7 @@ func (t *MoreData) DecodeScale(dec *scale.Decoder) (total int, err error) {
 		t.ByteSlice = field
 	}
 	{
-		field, n, err := scale.DecodeSliceOfByteSlice(dec)
+		field, n, err := scale.DecodeSliceOfByteSliceWithLimit(dec, 10)
 		if err != nil {
 			return total, err
 		}

--- a/scalegen/runner/testdata/data_scale.go.empty
+++ b/scalegen/runner/testdata/data_scale.go.empty
@@ -14,6 +14,16 @@ func (t *Data) DecodeScale(dec *scale.Decoder) (total int, err error) {
 	return total, nil
 }
 
+func (t *Name) EncodeScale(enc *scale.Encoder) (total int, err error) {
+
+	return total, nil
+}
+
+func (t *Name) DecodeScale(dec *scale.Decoder) (total int, err error) {
+
+	return total, nil
+}
+
 func (t *MoreData) EncodeScale(enc *scale.Encoder) (total int, err error) {
 
 	return total, nil


### PR DESCRIPTION
This closes https://github.com/spacemeshos/go-spacemesh/issues/4095

`scalegen` will now enforce a `scale:max=x` tag on all types that have variable length. These are `[]T` and `string`. `scalegen` will abort code generation when the expected tag is missing and print an error explaining the necessity for the tag.

Additionally types with nested variable length, like `[]string` and `[][]T` are now not allowed to be used any more with `scalegen`, since they cannot be tagged unambiguously. Instead users have to create custom types and nest them so every level can be tagged with a maximum size.