### PR TITLE
Allow to pass a custom fuzzing function to FuzzConsistency

### DIFF
--- a/tester/fuzz.go
+++ b/tester/fuzz.go
@@ -13,9 +13,9 @@ import (
 	"github.com/spacemeshos/go-scale"
 )
 
-func FuzzConsistency[T any, H scale.TypePtr[T]](f *testing.F) {
+func FuzzConsistency[T any, H scale.TypePtr[T]](f *testing.F, fuzzFuncs ...any) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		fuzzer := fuzz.NewFromGoFuzz(data)
+		fuzzer := fuzz.NewFromGoFuzz(data).Funcs(fuzzFuncs...)
 		var object T
 		fuzzer.Fuzz(&object)
 


### PR DESCRIPTION
Without this we cannot run `testing.FuzzConsistency` on types that have embedded interfaces (see common/types/malfeasance_test.go in this PR: https://github.com/spacemeshos/go-spacemesh/pull/4209/)