### PR TITLE
Return the correct number of bytes read from DecodeStructSliceWithLimit

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -304,21 +304,20 @@ func DecodeStructSlice[V any, H DecodablePtr[V]](d *Decoder) ([]V, int, error) {
 func DecodeStructSliceWithLimit[V any, H DecodablePtr[V]](d *Decoder, limit uint32) ([]V, int, error) {
 	lth, total, err := DecodeLen(d, limit)
 	if err != nil {
-		return nil, 0, err
+		return nil, total, err
 	}
 	if lth == 0 {
-		return nil, 0, nil
+		return nil, total, nil
 	}
 
 	value := make([]V, 0, lth)
-
 	for i := uint32(0); i < lth; i++ {
 		val, n, err := DecodeStruct[V, H](d)
+		total += n
 		if err != nil {
-			return nil, 0, err
+			return nil, total, err
 		}
 		value = append(value, val)
-		total += n
 	}
 	return value, total, nil
 }


### PR DESCRIPTION
Pre-requisite for https://github.com/spacemeshos/go-spacemesh/pull/4300

The function `DecodeStructSliceWithLimit` didn't return the correct number of consumed bytes from the buffer.