### PR TITLE
Fuzz consistency must also check number of bytes consumed

### DIFF
--- a/tester/fuzz.go
+++ b/tester/fuzz.go
@@ -21,7 +21,7 @@ func FuzzConsistency[T any, H scale.TypePtr[T]](f *testing.F, fuzzFuncs ...any) 
 
 		buf := bytes.NewBuffer(nil)
 		enc := scale.NewEncoder(buf)
-		_, err := H(&object).EncodeScale(enc)
+		n1, err := H(&object).EncodeScale(enc)
 		if errors.Is(err, scale.ErrEncodeTooManyElements) {
 			return
 		}
@@ -29,8 +29,10 @@ func FuzzConsistency[T any, H scale.TypePtr[T]](f *testing.F, fuzzFuncs ...any) 
 
 		dec := scale.NewDecoder(buf)
 		var decoded T
-		_, err = H(&decoded).DecodeScale(dec)
+		n2, err := H(&decoded).DecodeScale(dec)
 		require.NoError(t, err)
+
+		require.Equal(t, n1, n2)
 
 		if !cmp.Equal(object, decoded, cmpopts.EquateEmpty()) {
 			t.Errorf("decoded didn't match original: %s", cmp.Diff(object, decoded))

--- a/tester/fuzz.go
+++ b/tester/fuzz.go
@@ -26,6 +26,7 @@ func FuzzConsistency[T any, H scale.TypePtr[T]](f *testing.F, fuzzFuncs ...any) 
 			return
 		}
 		require.NoError(t, err)
+		require.Equal(t, n1, buf.Len())
 
 		dec := scale.NewDecoder(buf)
 		var decoded T


### PR DESCRIPTION
Following up to https://github.com/spacemeshos/go-spacemesh/issues/4386:

Although the cause of the issue is not in go-scale but rather in the hand written `EncodeScale`/`DecodeScale` methods, `FuzzConsistency` should detect a bug like this.

The fix now ensures the number of bytes encoded in `EncodeScale` matches what is returned by the method as well as how many bytes are consumed by `DecodeScale`.