### PR TITLE
allocate slice with struct once and decode into every item

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -356,14 +356,13 @@ func DecodeStructSliceWithLimit[V any, H DecodablePtr[V]](d *Decoder, limit uint
 		return nil, total, nil
 	}
 
-	value := make([]V, 0, lth)
+	value := make([]V, lth)
 	for i := uint32(0); i < lth; i++ {
-		val, n, err := DecodeStruct[V, H](d)
+		n, err := H(&value[i]).DecodeScale(d)
 		total += n
 		if err != nil {
 			return nil, total, err
 		}
-		value = append(value, val)
 	}
 	return value, total, nil
 }


### PR DESCRIPTION
otherwise every separate struct is allocated on heap, and later is copied into original array.