### PR TITLE
Update use of macos runner

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,7 +52,7 @@ jobs:
         os: 
           - ubuntu-latest
           - [self-hosted, linux-arm64]
-          - macos-latest
+          - macos-13
           - [self-hosted, macos, arm64]
           - windows-latest
     steps:


### PR DESCRIPTION
`macos-latest` is now a arm machine. Update to use an intel builder instead